### PR TITLE
Switch should not call terminate() in stop()

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1430,7 +1430,6 @@ class Switch( Node ):
            deleteIntfs: delete interfaces? (True)"""
         if deleteIntfs:
             self.deleteIntfs()
-        self.terminate()
 
     def __repr__( self ):
         "More informative string representation"


### PR DESCRIPTION

Fixes #121: Terminate() will call cleanup(), while cleanup() will clear the current shell, but start() does not recreate the shell. Moreover, in stop() in net.py, the stop() of Switch is called first, and terminate() is called, so there is no need to call terminate() in stop().